### PR TITLE
Adds basic pagination

### DIFF
--- a/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/components/BSPagination.java
+++ b/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/components/BSPagination.java
@@ -27,8 +27,57 @@ import quicksilver.webapp.simpleui.HtmlStream;
 
 public class BSPagination extends BSComponent {
 
-    @Override
-    public void render(HtmlStream stream) {
+    private final Link[] links;
+    private Link activeLink;
 
+    public BSPagination(Link... links) {
+	this.links = links;
     }
+
+    @Override
+    public void render(HtmlStream s) {
+	s.writeln("<nav>");
+	s.writeln("<ul class=\"pagination\">");
+	for (Link link : links) {
+		s.write("<li class=\"page-item");
+		if(link.isDisabled()) {
+			s.write(" disabled");
+		} else if (activeLink == link) {
+			s.write(" active\" aria-current=\"page");
+		}
+		s.write("\">");
+		//XXX: When disabled, the link should become a <span>
+		link.render(s);
+		s.writeln("</li>");
+	}
+	s.writeln("</ul>");
+	s.writeln("</nav>");
+    }
+
+	public void setActiveLink(Link l) {
+		this.activeLink = l;
+	}
+
+	public static class Link extends BSHyperlink {
+
+		private final boolean disabled;
+
+		public Link(String text, String url, boolean disabled) {
+			super(text, url);
+			insertTagAttribute(0, "class", "page-link");
+			this.disabled = disabled;
+			if (disabled) {
+				addTagAttribute("tabindex", "-1");
+				addTagAttribute("aria-disabled", "true");
+			}
+		}
+
+		public Link(String text, String url) {
+			this(text, url, false);
+		}
+
+		public boolean isDisabled() {
+			return disabled;
+		}
+	}
 }

--- a/simple-web-ui-toolkit/src/test/java/quicksilver/webapp/simpleui/bootstrap4/components/BSPaginationTest.java
+++ b/simple-web-ui-toolkit/src/test/java/quicksilver/webapp/simpleui/bootstrap4/components/BSPaginationTest.java
@@ -1,0 +1,37 @@
+package quicksilver.webapp.simpleui.bootstrap4.components;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import quicksilver.webapp.simpleui.HtmlStreamStringBuffer;
+
+public class BSPaginationTest {
+
+	@Test
+	public void testPagination() {
+		String expected = "<nav>\n"+
+			"<ul class=\"pagination\">\n"+
+    			"<li class=\"page-item disabled\"><a class=\"page-link\" href=\"#\" tabindex=\"-1\" aria-disabled=\"true\">\nPrevious</a>\n</li>\n"+
+    			"<li class=\"page-item\"><a class=\"page-link\" href=\"#\">\n1</a>\n</li>\n"+
+    			"<li class=\"page-item active\" aria-current=\"page\"><a class=\"page-link\" href=\"#\">\n2</a>\n</li>\n"+
+    			"<li class=\"page-item\"><a class=\"page-link\" href=\"#\">\n3</a>\n</li>\n"+
+    			"<li class=\"page-item\"><a class=\"page-link\" href=\"#\">\nNext</a>\n</li>\n"+
+  			"</ul>\n"+
+			"</nav>\n";
+
+		BSPagination.Link previous = new BSPagination.Link("Previous", "#", true);
+		BSPagination.Link one = new BSPagination.Link("1", "#");
+		BSPagination.Link two = new BSPagination.Link("2", "#");
+		BSPagination.Link three = new BSPagination.Link("3", "#");
+		BSPagination.Link next = new BSPagination.Link("Next", "#");
+
+		BSPagination p = new BSPagination(previous, one, two, three, next);
+		p.setActiveLink(two);
+
+	        HtmlStreamStringBuffer sb = new HtmlStreamStringBuffer();
+                p.render(sb);
+
+                assertEquals(expected, sb.getText());
+	}
+}

--- a/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/bootstrap/Pagination.java
+++ b/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/bootstrap/Pagination.java
@@ -33,7 +33,17 @@ public class Pagination extends AbstractComponentsBootstrapPage {
         panel.add(new BSText("<br>"));
         panel.add(new BSText("List of Pagination Components"));
         panel.add(new BSText("<br>"));
-        panel.add(new BSPagination());
+
+	BSPagination.Link previous = new BSPagination.Link("Previous", "#", true);
+	BSPagination.Link one = new BSPagination.Link("1", "#");
+	BSPagination.Link two = new BSPagination.Link("2", "#");
+	BSPagination.Link three = new BSPagination.Link("3", "#");
+	BSPagination.Link next = new BSPagination.Link("Next", "#");
+
+	BSPagination p = new BSPagination(previous, one, two, three, next);
+	p.setActiveLink(two);
+
+	panel.add(p);
 
         return panel;
     }


### PR DESCRIPTION
Minor commit.

I don't like I had to invent the Link that extends BSHyperlink just to have a way to add some attributes. It would seem more natural for users to use the same BSHyperlink class and internally that to be rendered / transformed as to please the pagination rules. Otherwise we risk being more verbose than HTML...