### PR TITLE
Adds simple logging to actually see something...

### DIFF
--- a/simple-webserver/pom.xml
+++ b/simple-webserver/pom.xml
@@ -24,6 +24,11 @@
             <artifactId>web</artifactId>
             <version>${project.version}</version>
         </dependency>
+	<dependency>
+		<groupId>org.slf4j</groupId>
+		<artifactId>slf4j-simple</artifactId>
+		<version>1.7.25</version>
+	</dependency>
     </dependencies>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Seems that with only the slf4j-api dependency we don't see anything on the terminal, not even the http port number (which I always have to search for...)

Using 1.7.25 (and not the latest 1.7.26) since it's a dependency of com.zaxxer:HikariCP:jar:3.2.0