### PR TITLE
Prepares up-for-grabs config file

### DIFF
--- a/up-for-grabs.net.yml
+++ b/up-for-grabs.net.yml
@@ -1,0 +1,9 @@
+name: Quicksilver
+desc: Simple Java Application Server with a Bootstrap frontend
+site: https://github.com/nielsgron/quicksilver
+tags:
+- Java
+- bootstrap
+upforgrabs:
+  name: good first issue
+  link: https://github.com/nielsgron/quicksilver/labels/good%20first%20issue


### PR DESCRIPTION
I think there are many tasks here that could be good for first time contributors.

https://up-for-grabs.net seems to be quite popular with promoting easy issues and we need to register with them using a yml file.

I think the current file is OK although perhaps needs more tags besides Java and Bootstrap.

If the file is OK we need to to submit it as a PR to that project so it's added here https://github.com/up-for-grabs/up-for-grabs.net/tree/gh-pages/_data/projects

Then, of course, it would be nice to actually have some issues with that tag.