### PR TITLE
Fixes example datafeeds

### DIFF
--- a/simple-commons/src/main/java/quicksilver/commons/datafeed/DataFeed.java
+++ b/simple-commons/src/main/java/quicksilver/commons/datafeed/DataFeed.java
@@ -78,13 +78,22 @@ public abstract class DataFeed extends HttpRequester {
         }
 
         dataPayload = requestURLToMemory(url);
+        dataPayload = transformPayload(dataPayload);
 
         buildDataSet();
 
     }
 
+    protected byte[] transformPayload(byte[] text) {
+        return text;
+    }
+
     public void addParameter(String key, String value) {
         parameters.put(key, value);
+    }
+
+    public String getParameter(String key) {
+        return parameters.get(key);
     }
 
     public Table getDataTable() {

--- a/simple-commons/src/main/java/quicksilver/commons/datafeed/DataFeedJSON.java
+++ b/simple-commons/src/main/java/quicksilver/commons/datafeed/DataFeedJSON.java
@@ -15,24 +15,61 @@
  */
 package quicksilver.commons.datafeed;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.StringReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import tech.tablesaw.io.Source;
+import tech.tablesaw.io.json.JsonReadOptions;
 import tech.tablesaw.io.json.JsonReader;
 
 public class DataFeedJSON extends DataFeed {
 
+    private final String jsonPath;
+
     public DataFeedJSON(String baseURLString) {
+        this(baseURLString, "");
+    }
+
+    public DataFeedJSON(String baseURLString, String jsonPath) {
         super(baseURLString);
+        this.jsonPath = jsonPath;
     }
 
     @Override
     protected void buildDataSet() {
+        JsonReadOptions.Builder builder = JsonReadOptions.builder(new Source(new ByteArrayInputStream(dataPayload)));
         try {
-            dataTable = new JsonReader().read(new Source(new ByteArrayInputStream(dataPayload)));
+            if (!jsonPath.isEmpty()) {
+                builder = applyPath(builder, jsonPath);
+            }
+            dataTable = new JsonReader().read(builder.build());
         } catch (IOException ex) {
             //ignore?
         }
+    }
+
+    private JsonReadOptions.Builder applyPath(JsonReadOptions.Builder builder, String jsonPath) throws IOException {
+        //only in Tablesaw 0.36.1+, see https://github.com/jtablesaw/tablesaw/pull/684
+        // builder = builder.path(jsonPath);
+        //... otherwise try reflection:
+        try {
+            Method m = JsonReadOptions.Builder.class.getDeclaredMethod("path", String.class);
+            builder = (JsonReadOptions.Builder) m.invoke(builder, jsonPath);
+        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+            //parse JSON, extract the subtree here and serialize it for tablesaw
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode tree = mapper.readTree(builder.build().source().inputStream());
+
+            tree = tree.at(jsonPath);
+            String newText = mapper.writeValueAsString(tree);
+
+            builder = JsonReadOptions.builder(new Source(new StringReader(newText)));
+        }
+        return builder;
     }
 
 }

--- a/simple-commons/src/main/java/quicksilver/commons/datafeed/impl/DataFeedNewsAPI.java
+++ b/simple-commons/src/main/java/quicksilver/commons/datafeed/impl/DataFeedNewsAPI.java
@@ -1,6 +1,5 @@
 package quicksilver.commons.datafeed.impl;
 
-import quicksilver.commons.datafeed.DataFeed;
 import quicksilver.commons.datafeed.DataFeedJSON;
 import tech.tablesaw.api.Table;
 
@@ -20,8 +19,7 @@ public class DataFeedNewsAPI extends DataFeedJSON {
     public static String SECTION_TOPHEADLINES = "top-headlines";
 
     public DataFeedNewsAPI(String section) {
-        super("https://newsapi.org/v2/" + section);
-
+        super("https://newsapi.org/v2/" + section, "/articles");
     }
 
     public void setSearchTerm(String value) {

--- a/simple-commons/src/main/java/quicksilver/commons/datafeed/impl/DataFeedTwitter.java
+++ b/simple-commons/src/main/java/quicksilver/commons/datafeed/impl/DataFeedTwitter.java
@@ -1,6 +1,5 @@
 package quicksilver.commons.datafeed.impl;
 
-import quicksilver.commons.datafeed.DataFeed;
 import quicksilver.commons.datafeed.DataFeedJSON;
 import tech.tablesaw.api.Table;
 
@@ -13,7 +12,7 @@ public class DataFeedTwitter extends DataFeedJSON {
     // URL Example : https://api.twitter.com/1.1/search/tweets.json?q=from%3Atwitterdev&result_type=mixed&count=2
 
     public DataFeedTwitter() {
-        super("https://api.twitter.com/1.1/search/tweets.json");
+        super("https://api.twitter.com/1.1/search/tweets.json", "/statuses");
 
     }
 

--- a/simple-commons/src/test/java/quicksilver/commons/datafeed/impl/DataFeedTwitterImplTest.java
+++ b/simple-commons/src/test/java/quicksilver/commons/datafeed/impl/DataFeedTwitterImplTest.java
@@ -1,0 +1,37 @@
+package quicksilver.commons.datafeed.impl;
+
+import java.io.IOException;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import tech.tablesaw.api.Table;
+
+public class DataFeedTwitterImplTest {
+
+    static class CachedFeed extends DataFeedTwitter {
+
+        @Override
+        public void request() throws IOException {
+            byte[] buff = new byte[10 * 1024 * 1024];
+            int len = IOUtils.read(DataFeedTwitterImplTest.class.getResourceAsStream("twitter.json"), buff, 0, buff.length);
+            dataPayload = new byte[len];
+            System.arraycopy(buff, 0, dataPayload, 0, len);
+
+            buildDataSet();
+        }
+
+    }
+
+    @Test
+    public void testCached() throws IOException {
+        CachedFeed dataFeed = new CachedFeed();
+
+        dataFeed.request();
+        Table dataTable = dataFeed.getDataTable();
+        System.out.print(dataTable.structure());
+        System.out.print(dataTable.print());
+        
+        Assert.assertTrue(dataTable.rowCount() > 0);
+    }
+
+}

--- a/simple-commons/src/test/resources/quicksilver/commons/datafeed/impl/twitter.json
+++ b/simple-commons/src/test/resources/quicksilver/commons/datafeed/impl/twitter.json
@@ -1,0 +1,517 @@
+{
+    "statuses": [
+        {
+            "created_at": " text2050157789",
+            "id": 1455457175
+            ,
+            "id_str": " text-1449078967",
+            "text": " text-1057322719",
+            "truncated": true
+            ,
+            "entities": {
+                "hashtags": [
+                ]
+                ,
+                "symbols": [
+                ]
+                ,
+                "user_mentions": [
+                ]
+                ,
+                "urls": [
+                    {
+                        "url": " text1843196608",
+                        "expanded_url": " text-1389431225",
+                        "display_url": " text790998671",
+                        "indices": [
+                            -2067617974
+                                    , -465762254
+                        ]
+                    }
+                ]
+            }
+            ,
+            "metadata": {
+                "iso_language_code": " text-576857296",
+                "result_type": " text1031848325"
+            }
+            ,
+            "source": " text2098048592",
+            "in_reply_to_status_id": null
+            ,
+            "in_reply_to_status_id_str": null
+            ,
+            "in_reply_to_user_id": null
+            ,
+            "in_reply_to_user_id_str": null
+            ,
+            "in_reply_to_screen_name": null
+            ,
+            "user": {
+                "id": -2013123842
+                ,
+                "id_str": " text-2025551629",
+                "name": " text202214897",
+                "screen_name": " text-235538044",
+                "location": " text-1857587669",
+                "description": " text918881261",
+                "url": " text-1411651737",
+                "entities": {
+                    "url": {
+                        "urls": [
+                            {
+                                "url": " text-772248554",
+                                "expanded_url": " text203289198",
+                                "display_url": " text51509144",
+                                "indices": [
+                                    333117148
+                                            , -578444508
+                                ]
+                            }
+                        ]
+                    }
+                    ,
+                    "description": {
+                        "urls": [
+                            {
+                                "url": " text1811839456",
+                                "expanded_url": " text-1452252622",
+                                "display_url": " text16033656",
+                                "indices": [
+                                    -505035789
+                                            , 1758044912
+                                ]
+                            }
+                        ]
+                    }
+                }
+                ,
+                "protected": true
+                ,
+                "followers_count": -998910309
+                ,
+                "friends_count": 1169329327
+                ,
+                "listed_count": 999582331
+                ,
+                "created_at": " text1910957722",
+                "favourites_count": 479099011
+                ,
+                "utc_offset": null
+                ,
+                "time_zone": null
+                ,
+                "geo_enabled": true
+                ,
+                "verified": true
+                ,
+                "statuses_count": 486708626
+                ,
+                "lang": " text-158434264",
+                "contributors_enabled": true
+                ,
+                "is_translator": true
+                ,
+                "is_translation_enabled": null
+                ,
+                "profile_background_color": " text-1619823144",
+                "profile_background_image_url": " text-878438716",
+                "profile_background_image_url_https": " text-2042420895",
+                "profile_background_tile": null
+                ,
+                "profile_image_url": " text711189214",
+                "profile_image_url_https": " text-1283165607",
+                "profile_banner_url": " text-1557002229",
+                "profile_link_color": " text857950565",
+                "profile_sidebar_border_color": " text-1401195458",
+                "profile_sidebar_fill_color": " text763854448",
+                "profile_text_color": " text2057809342",
+                "profile_use_background_image": null
+                ,
+                "has_extended_profile": null
+                ,
+                "default_profile": true
+                ,
+                "default_profile_image": true
+                ,
+                "following": true
+                ,
+                "follow_request_sent": true
+                ,
+                "notifications": true
+                ,
+                "translator_type": " text-883067908"
+            }
+            ,
+            "geo": null
+            ,
+            "coordinates": null
+            ,
+            "place": null
+            ,
+            "contributors": null
+            ,
+            "is_quote_status": true
+            ,
+            "quoted_status_id": 1964476711
+            ,
+            "quoted_status_id_str": " text-1828202418",
+            "quoted_status": {
+                "created_at": " text1840627993",
+                "id": 1008698613
+                ,
+                "id_str": " text1871579519",
+                "text": " text1120760948",
+                "truncated": true
+                ,
+                "entities": {
+                    "hashtags": [
+                    ]
+                    ,
+                    "symbols": [
+                    ]
+                    ,
+                    "user_mentions": [
+                    ]
+                    ,
+                    "urls": [
+                        {
+                            "url": " text-1388261734",
+                            "expanded_url": " text39141149",
+                            "display_url": " text1007611955",
+                            "indices": [
+                                2091830114
+                                        , 209027999
+                            ]
+                        }
+                    ]
+                }
+                ,
+                "metadata": {
+                    "iso_language_code": " text1161734938",
+                    "result_type": " text1166052219"
+                }
+                ,
+                "source": " text-926593388",
+                "in_reply_to_status_id": null
+                ,
+                "in_reply_to_status_id_str": null
+                ,
+                "in_reply_to_user_id": null
+                ,
+                "in_reply_to_user_id_str": null
+                ,
+                "in_reply_to_screen_name": null
+                ,
+                "user": {
+                    "id": 2082583116
+                    ,
+                    "id_str": " text-1559914634",
+                    "name": " text-1733755550",
+                    "screen_name": " text-817907538",
+                    "location": " text-348180558",
+                    "description": " text-1868397058",
+                    "url": " text122732677",
+                    "entities": {
+                        "url": {
+                            "urls": [
+                                {
+                                    "url": " text-1374901003",
+                                    "expanded_url": " text-1563693011",
+                                    "display_url": " text-2104321459",
+                                    "indices": [
+                                        981611802
+                                                , 1313561089
+                                    ]
+                                }
+                            ]
+                        }
+                        ,
+                        "description": {
+                            "urls": [
+                            ]
+                        }
+                    }
+                    ,
+                    "protected": true
+                    ,
+                    "followers_count": -287504883
+                    ,
+                    "friends_count": -236626525
+                    ,
+                    "listed_count": -1765377484
+                    ,
+                    "created_at": " text-2145971280",
+                    "favourites_count": 1703962231
+                    ,
+                    "utc_offset": null
+                    ,
+                    "time_zone": null
+                    ,
+                    "geo_enabled": true
+                    ,
+                    "verified": true
+                    ,
+                    "statuses_count": 37907450
+                    ,
+                    "lang": " text-327149756",
+                    "contributors_enabled": true
+                    ,
+                    "is_translator": true
+                    ,
+                    "is_translation_enabled": null
+                    ,
+                    "profile_background_color": " text1126045790",
+                    "profile_background_image_url": " text677091469",
+                    "profile_background_image_url_https": " text-1359716773",
+                    "profile_background_tile": null
+                    ,
+                    "profile_image_url": " text1367882211",
+                    "profile_image_url_https": " text-1664944814",
+                    "profile_banner_url": " text1131655884",
+                    "profile_link_color": " text671581805",
+                    "profile_sidebar_border_color": " text-1472492595",
+                    "profile_sidebar_fill_color": " text1686847098",
+                    "profile_text_color": " text-1544729930",
+                    "profile_use_background_image": null
+                    ,
+                    "has_extended_profile": null
+                    ,
+                    "default_profile": true
+                    ,
+                    "default_profile_image": true
+                    ,
+                    "following": true
+                    ,
+                    "follow_request_sent": true
+                    ,
+                    "notifications": true
+                    ,
+                    "translator_type": " text1918914382"
+                }
+                ,
+                "geo": null
+                ,
+                "coordinates": null
+                ,
+                "place": null
+                ,
+                "contributors": null
+                ,
+                "is_quote_status": true
+                ,
+                "retweet_count": -9444048
+                ,
+                "favorite_count": 747998555
+                ,
+                "favorited": true
+                ,
+                "retweeted": true
+                ,
+                "possibly_sensitive": true
+                ,
+                "lang": " text-1241957712"
+            }
+            ,
+            "retweet_count": -2020190299
+            ,
+            "favorite_count": 1587306279
+            ,
+            "favorited": true
+            ,
+            "retweeted": true
+            ,
+            "possibly_sensitive": true
+            ,
+            "lang": " text-1191445694"
+        }
+        , {
+            "created_at": " text1938645548",
+            "id": -1986094857
+            ,
+            "id_str": " text-1106146688",
+            "text": " text-1515746625",
+            "truncated": true
+            ,
+            "entities": {
+                "hashtags": [
+                    {
+                        "text": " text-1089027062",
+                        "indices": [
+                            606089274
+                                    , -457716027
+                        ]
+                    }
+                ]
+                ,
+                "symbols": [
+                ]
+                ,
+                "user_mentions": [
+                ]
+                ,
+                "urls": [
+                    {
+                        "url": " text-378784685",
+                        "expanded_url": " text935634747",
+                        "display_url": " text-1091265625",
+                        "indices": [
+                            -140102278
+                                    , -829650328
+                        ]
+                    }
+                ]
+            }
+            ,
+            "metadata": {
+                "iso_language_code": " text198352295",
+                "result_type": " text-1676836396"
+            }
+            ,
+            "source": " text-2075908702",
+            "in_reply_to_status_id": null
+            ,
+            "in_reply_to_status_id_str": null
+            ,
+            "in_reply_to_user_id": null
+            ,
+            "in_reply_to_user_id_str": null
+            ,
+            "in_reply_to_screen_name": null
+            ,
+            "user": {
+                "id": -415291263
+                ,
+                "id_str": " text-1825467055",
+                "name": " text-1677240831",
+                "screen_name": " text1204605832",
+                "location": " text398418353",
+                "description": " text5134263",
+                "url": " text22113713",
+                "entities": {
+                    "url": {
+                        "urls": [
+                            {
+                                "url": " text-2026673989",
+                                "expanded_url": " text1511383633",
+                                "display_url": " text666246014",
+                                "indices": [
+                                    -951493764
+                                            , 1288906841
+                                ]
+                            }
+                        ]
+                    }
+                    ,
+                    "description": {
+                        "urls": [
+                            {
+                                "url": " text-1453508372",
+                                "expanded_url": " text406850638",
+                                "display_url": " text-1171217629",
+                                "indices": [
+                                    -1236855920
+                                            , 101808766
+                                ]
+                            }
+                        ]
+                    }
+                }
+                ,
+                "protected": true
+                ,
+                "followers_count": -160633605
+                ,
+                "friends_count": 2076252901
+                ,
+                "listed_count": -931605918
+                ,
+                "created_at": " text-1304857122",
+                "favourites_count": -1524877340
+                ,
+                "utc_offset": null
+                ,
+                "time_zone": null
+                ,
+                "geo_enabled": true
+                ,
+                "verified": true
+                ,
+                "statuses_count": -1483370992
+                ,
+                "lang": " text716104871",
+                "contributors_enabled": true
+                ,
+                "is_translator": true
+                ,
+                "is_translation_enabled": null
+                ,
+                "profile_background_color": " text1043016311",
+                "profile_background_image_url": " text1036542368",
+                "profile_background_image_url_https": " text-807308070",
+                "profile_background_tile": null
+                ,
+                "profile_image_url": " text526278488",
+                "profile_image_url_https": " text1553233470",
+                "profile_banner_url": " text426910166",
+                "profile_link_color": " text-1756637840",
+                "profile_sidebar_border_color": " text50641417",
+                "profile_sidebar_fill_color": " text-2121519393",
+                "profile_text_color": " text998041195",
+                "profile_use_background_image": null
+                ,
+                "has_extended_profile": null
+                ,
+                "default_profile": true
+                ,
+                "default_profile_image": true
+                ,
+                "following": true
+                ,
+                "follow_request_sent": true
+                ,
+                "notifications": true
+                ,
+                "translator_type": " text-1653693873"
+            }
+            ,
+            "geo": null
+            ,
+            "coordinates": null
+            ,
+            "place": null
+            ,
+            "contributors": null
+            ,
+            "is_quote_status": true
+            ,
+            "retweet_count": 982675639
+            ,
+            "favorite_count": 1275009593
+            ,
+            "favorited": true
+            ,
+            "retweeted": true
+            ,
+            "possibly_sensitive": true
+            ,
+            "lang": " text-1086532381"
+        }
+    ]
+    ,
+    "search_metadata": {
+        "completed_in": -1178785325
+        ,
+        "max_id": -2076738108
+        ,
+        "max_id_str": " text-1777370612",
+        "next_results": " text-1978073600",
+        "query": " text1638492941",
+        "refresh_url": " text183431230",
+        "count": -1355473167
+        ,
+        "since_id": -315971665
+        ,
+        "since_id_str": " text1812554713"
+    }
+}


### PR DESCRIPTION
Loads JSON subtrees for Twitter and NewsAPI data feeds. This needs the upstream patch https://github.com/jtablesaw/tablesaw/pull/684 but also works with the current version by parsing/modifying the JSON before sending to Tablesaw (which isn't very efficient, but works).

Transforming the DataFeedAlphaVantage JSON format into something Tablesaw understands. The format they use is rather odd as they use an object with a field per timestamp. This again is inefficient because of the 2nd JSON parsing. Not sure how it could be done otherwise, maybe via some XSLT-like processing of the JSON tree inside the Tablesaw reader, although it seems a bit heavy...
