### PR TITLE
Uses OkHttp for the DataFeed

### DIFF
--- a/simple-commons/pom.xml
+++ b/simple-commons/pom.xml
@@ -129,6 +129,11 @@
             <artifactId>rome</artifactId>
             <version>1.12.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.2.1</version>
+        </dependency>
     </dependencies>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/simple-commons/src/main/java/quicksilver/commons/datafeed/AbstractHttpRequester.java
+++ b/simple-commons/src/main/java/quicksilver/commons/datafeed/AbstractHttpRequester.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018-2019 Niels Gron and Contributors All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package quicksilver.commons.datafeed;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+
+public abstract class AbstractHttpRequester {
+
+    public byte[] requestURL(URL source) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        requestURL(source, baos);
+        return baos.toByteArray();
+    }
+
+    public void requestURL(URL source, File destination) throws IOException {
+        // opens an output stream to save into file
+        try (FileOutputStream outputStream = new FileOutputStream(destination)) {
+            requestURL(source, outputStream);
+        }
+    }
+
+    public abstract void requestURL(URL source, OutputStream outputStream) throws IOException;
+}

--- a/simple-commons/src/main/java/quicksilver/commons/datafeed/DataFeed.java
+++ b/simple-commons/src/main/java/quicksilver/commons/datafeed/DataFeed.java
@@ -23,7 +23,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class DataFeed extends HttpRequester {
+public abstract class DataFeed extends OkHttpRequester {
 
     // Members for URL building
     private String baseURLString;
@@ -81,7 +81,7 @@ public abstract class DataFeed extends HttpRequester {
             url = null;
         }
 
-        dataPayload = requestURLToMemory(url);
+        dataPayload = requestURL(url);
         dataPayload = transformPayload(dataPayload);
 
         buildDataSet();

--- a/simple-commons/src/main/java/quicksilver/commons/datafeed/HttpRequester.java
+++ b/simple-commons/src/main/java/quicksilver/commons/datafeed/HttpRequester.java
@@ -16,9 +16,7 @@
 
 package quicksilver.commons.datafeed;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -27,7 +25,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import org.apache.commons.io.IOUtils;
 
-public class HttpRequester {
+public class HttpRequester extends AbstractHttpRequester {
 
     private String contentEncoding;
     private String contentType;
@@ -38,22 +36,9 @@ public class HttpRequester {
 
     private int responseCode;
 
-    public byte[] requestURLToMemory(URL source) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        requestURLToFile(source, baos);
-        return baos.toByteArray();
-    }
-
-    public void requestURLToFile(URL source, File destination) throws IOException {
-            // opens an output stream to save into file
-            try(FileOutputStream outputStream = new FileOutputStream(destination)) {
-                requestURLToFile(source, outputStream);
-            }
-    }
-
     // Java Http
-    public void requestURLToFile(URL source, OutputStream outputStream ) throws IOException {
+    @Override
+    public void requestURL(URL source, OutputStream outputStream ) throws IOException {
         // Get an instance of a HttpURLConnection
         URLConnection connection = source.openConnection();
         HttpURLConnection httpConnection = connection instanceof HttpURLConnection ? (HttpURLConnection) connection : null;
@@ -118,7 +103,7 @@ public class HttpRequester {
 
         HttpRequester requester = new HttpRequester();
         try {
-            requester.requestURLToFile(new URL(fileURL), new File(savedFileName));
+            requester.requestURL(new URL(fileURL), new File(savedFileName));
         } catch (IOException ex) {
             ex.printStackTrace();
         }

--- a/simple-commons/src/main/java/quicksilver/commons/datafeed/OkHttpRequester.java
+++ b/simple-commons/src/main/java/quicksilver/commons/datafeed/OkHttpRequester.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018-2019 Niels Gron and Contributors All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quicksilver.commons.datafeed;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.apache.commons.io.IOUtils;
+
+public class OkHttpRequester extends AbstractHttpRequester {
+
+    public final OkHttpClient client = new OkHttpClient.Builder()
+            //.cache(new Cache(cacheDir, cacheSize))
+            .build();
+
+    @Override
+    public void requestURL(URL source, OutputStream outputStream) throws IOException {
+        //turns out OkHttp doesn't handle file://
+        if ("file".equals(source.getProtocol())) {
+            try (FileInputStream fos = new FileInputStream(new File(source.toURI()))) {
+                IOUtils.copy(fos, outputStream);
+                return;
+            } catch (URISyntaxException use) {
+                //ignore, let OkHttp also try...
+            }
+        }
+
+        Request request = new Request.Builder()
+                .url(source)
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            ResponseBody body = response.body();
+            if (body == null) {
+                throw new IOException("Null body");
+            }
+            IOUtils.copy(body.byteStream(), outputStream);
+        }
+    }
+
+}


### PR DESCRIPTION
Using `OkHttp` right now is the same as using `URLConnection`.

In the future perhaps caching might be worth looking into. Right now each `DataFeed` / `OkHttpRequester` has an `OkHttpClient`. Since I assume caching should be for all `Datafeed`s, we should use a single client for all.

BTW, I'm not sure why `DataFeed` must extend the `(Ok)HttpRequester`. It makes more sense for a `DataFeed` to *contain* a `HttpRequester` (or perhaps to receive a `HttpRequester` to use). If we can reuse the `HttpRequester` among multiple `DataFeed` instances it becomes easy to have a single caching folder.