### PR TITLE
Adds basic TreemapPlot

### DIFF
--- a/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/charts/TSTreeMapChartPanel.java
+++ b/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/charts/TSTreeMapChartPanel.java
@@ -17,7 +17,7 @@
 package quicksilver.webapp.simpleui.bootstrap4.charts;
 
 import tech.tablesaw.api.Table;
-import tech.tablesaw.plotly.api.PiePlot;
+import tech.tablesaw.plotly.api.TreemapPlot;
 import tech.tablesaw.plotly.components.Figure;
 
 public class TSTreeMapChartPanel extends TSFigurePanel {
@@ -28,7 +28,7 @@ public class TSTreeMapChartPanel extends TSFigurePanel {
         Figure figure = null;
 
         try {
-            figure = PiePlot.create("", table, "Name", "Value");
+            figure = TreemapPlot.create("", table, "Name", "Value");
         } catch ( Exception e ) {
             e.printStackTrace();
         }

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/TreemapPlot.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/TreemapPlot.java
@@ -1,0 +1,39 @@
+package tech.tablesaw.plotly.api;
+
+import java.util.Arrays;
+import tech.tablesaw.api.Table;
+import tech.tablesaw.plotly.components.Figure;
+import tech.tablesaw.plotly.traces.TreemapTrace;
+
+public class TreemapPlot {
+
+    /**
+     *
+     * @param title
+     * @param table
+     * @param col
+     * @param parentCol the parent column, which is assumed to be a separate list of entities compared to `col`.
+     * @return
+     */
+    public static Figure create(String title, Table table, String col, String parentCol) {
+        Object[] children = table.column(col).asObjectArray();
+        Object[] parents = table.column(parentCol).asObjectArray();
+
+        Object[] labels = new Object[children.length + parents.length];
+
+        //fill labels with both children and parents
+        System.arraycopy(children, 0, labels, 0, children.length);
+        System.arraycopy(parents, 0, labels, children.length, parents.length);
+
+        Object[] labelParents = new Object[labels.length];
+        System.arraycopy(parents, 0, labelParents, 0, parents.length);
+        //other labels are empty
+        Arrays.fill(labelParents, parents.length, labelParents.length, "");
+
+        TreemapTrace trace = TreemapTrace.builder(
+                labels,
+                labelParents)
+                .build();
+        return new Figure(trace);
+    }
+}

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/traces/TreemapTrace.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/traces/TreemapTrace.java
@@ -1,0 +1,81 @@
+package tech.tablesaw.plotly.traces;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Map;
+import tech.tablesaw.columns.Column;
+import static tech.tablesaw.plotly.Utils.dataAsString;
+
+public class TreemapTrace extends AbstractTrace {
+
+    private final Object[] labels;
+    private final Object[] parents;
+
+    public TreemapTrace(TreemapBuilder builder) {
+        super(builder);
+
+        this.labels = builder.labels;
+        this.parents = builder.parents;
+    }
+
+    @Override
+    public String asJavascript(int i) {
+        Writer writer = new StringWriter();
+        PebbleTemplate compiledTemplate;
+
+        try {
+            compiledTemplate = engine.getTemplate("trace_template2.html");
+            compiledTemplate.evaluate(writer, getContext(i));
+        } catch (PebbleException | IOException e) {
+            e.printStackTrace();
+        }
+        return writer.toString();
+    }
+
+    private Map<String, Object> getContext(int i) {
+
+        Map<String, Object> context = super.getContext();
+
+        //these two don't make sense for treemap
+        context.remove("xAxis");
+        context.remove("yAxis");
+
+        context.put("variableName", "trace" + i);
+        context.put("labels", dataAsString(labels));
+        context.put("parents", dataAsString(parents));
+        return context;
+    }
+
+    public static TreemapBuilder builder(Object[] labels, Object[] parents) {
+        return new TreemapBuilder(labels, parents);
+    }
+
+    public static class TreemapBuilder extends TraceBuilder {
+
+        private static final String type = "treemap";
+        final Object[] labels;
+        final Object[] parents;
+
+        TreemapBuilder(Object[] labels, Object[] parents) {
+            this.labels = labels;
+            this.parents = parents;
+        }
+
+        TreemapBuilder(Column<?> labels, Column<?> parents) {
+            this.labels = columnToStringArray(labels);
+            this.parents = columnToStringArray(parents);
+        }
+
+        public TreemapTrace build() {
+            return new TreemapTrace(this);
+        }
+
+        @Override
+        protected String getType() {
+            return type;
+        }
+    }
+}

--- a/simple-web-ui-toolkit/src/main/resources/trace_template2.html
+++ b/simple-web-ui-toolkit/src/main/resources/trace_template2.html
@@ -1,0 +1,93 @@
+//<!--
+//This is the Tablesaw trace_template with the added labels and parents fields.
+//Tablesaw is under the Apache 2.0 license.
+//-->
+var {{variableName}} =
+{
+{% if x is not null %}
+x: {{x | raw}},
+{% endif %}
+{% if y is not null %}
+y: {{y | raw}},
+{% endif %}
+{% if open is not null %}
+open: {{open | raw}},
+{% endif %}
+{% if high is not null %}
+high: {{high | raw}},
+{% endif %}
+{% if low is not null %}
+low: {{low | raw}},
+{% endif %}
+{% if close is not null %}
+close: {{close | raw}},
+{% endif %}
+{% if increasing is not null %}
+increasing: {{increasing | raw}},
+{% endif %}
+{% if decreasing is not null %}
+decreasing: {{decreasing | raw}},
+{% endif %}
+{% if z is not null %}
+z: {{z | raw}},
+{% endif %}
+{% if showLegend is not null %}
+showlegend: {{showLegend}},
+{% endif %}
+{% if hoverlabel is not null %}
+hoverlabel: {{hoverlabel | raw }},
+{% endif %}
+{% if marker is not null %}
+marker: {{marker | raw }},
+{% endif %}
+{% if text is not null %}
+text: {{text | raw }},
+{% endif %}
+{% if mode is not null %}
+mode: '{{mode}}',
+{% endif %}
+{% if line is not null %}
+line: {{line | raw }},
+{% endif %}
+{% if orientation is not null %}
+orientation: '{{orientation}}',
+{% endif %}
+{% if opacity is not null %}
+opacity: '{{opacity}}',
+{% endif %}
+{% if nBinsX is not null %}
+nbinsx: {{nBinsX}},
+{% endif %}
+{% if autoBinX is not null %}
+autobinx: {{autoBinX}},
+{% endif %}
+{% if nBinsY is not null %}
+nbinsy: {{nBinsY}},
+{% endif %}
+{% if autoBinY is not null %}
+autobiny: {{autoBinY}},
+{% endif %}
+{% if visible is not null %}
+visible: '{{visible}}',
+{% endif %}
+{% if fill is not null %}
+fill: '{{fill}}',
+{% endif %}
+{% if xAxis is not null %}
+xaxis: '{{xAxis}}',
+{% endif %}
+{% if yAxis is not null %}
+yaxis: '{{yAxis}}',
+{% endif %}
+{% if fillColor is not null %}
+fillcolor: '{{fillColor}}',
+{% endif %}
+{% if labels is not null %}
+labels: {{labels | raw}},
+{% endif %}
+{% if parents is not null %}
+parents: {{parents | raw}},
+{% endif %}
+type: '{{type}}',
+name: '{{name}}',
+};

--- a/simple-web-ui-toolkit/src/test/java/tech/tablesaw/plotly/traces/TreemapTraceTest.java
+++ b/simple-web-ui-toolkit/src/test/java/tech/tablesaw/plotly/traces/TreemapTraceTest.java
@@ -1,0 +1,17 @@
+package tech.tablesaw.plotly.traces;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TreemapTraceTest {
+
+    @Test
+    public void testMe() {
+        TreemapTrace trace = TreemapTrace.builder(new String[]{"a", "b", "c"}, new String[]{"b", "", ""}).build();
+
+        String js = trace.asJavascript(0);
+
+        Assert.assertTrue(js, js.contains("labels"));
+    }
+
+}

--- a/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
+++ b/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
@@ -33,7 +33,10 @@ public class ChartsTreemap extends AbstractComponentsChartsPage {
         QuickBodyPanel body = new QuickBodyPanel();
 
         // Add Chart
-        Table table = Charts.createPieDataSet(true);
+        Table table = Charts.createMarketDataSet();
+        //"Sector", "Company" -> "Name", "Value" aka child, parent
+        table.column("Sector").setName("Value");
+        table.column("Company").setName("Name");
 
         body.addRowOfColumns(
                 Charts.addTreemapChart(table, "div1", "Wide Chart")


### PR DESCRIPTION
This is basically what a Tablesaw PR for `TreemapPlot` should hold plus an example in Quicksilver.

Two remarks here:

* note how in `TreemapPlot.create` I assume the two columns are 'unrelated'. This means that you have different categories (company - sector). I assume they are unrelated to build the full list of "labels" in Plotly terminology. If these columns are related (like the example of Adam / Eve family tree) then one needs to make sure there are no duplicates. I'll add this these days.

* In `ChartsTreemap` I rename the column names because `TSTreeMapChartPanel` has hardcoded column names. I should probably add those as arguments... (If you want I can fix this for this PR).