### PR TITLE
TreemapPlot fixes and demo

### DIFF
--- a/simple-commons/src/main/java/quicksilver/commons/data/TSDataSetFactory.java
+++ b/simple-commons/src/main/java/quicksilver/commons/data/TSDataSetFactory.java
@@ -205,6 +205,19 @@ public class TSDataSetFactory {
         return dataSet;
     }
 
+    public static TSDataSet createSampleFamilyTreeData() {
+        TSDataSet dataSet = createSampleDataSet(new String[]{"Name", "Parent"},
+                new Class[]{String.class, String.class});
+        dataSet.addRow(new Object[] { "FreeBSD"         , "386BSD" });
+        dataSet.addRow(new Object[] { "OpenBSD"         , "NetBSD" });
+        dataSet.addRow(new Object[] { "NetBSD"          , "386BSD" });
+        dataSet.addRow(new Object[] { "DragonFly BSD"   , "FreeBSD" });
+        dataSet.addRow(new Object[] { "macOS"           , "Darwin" });
+        dataSet.addRow(new Object[] { "Darwin"          , "FreeBSD" });
+
+        return dataSet;
+    }
+
     public static TSDataSet createSampleCountryEconomicData() {
 
         // Country, GDP, Population

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/TreemapPlot.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/TreemapPlot.java
@@ -1,39 +1,47 @@
 package tech.tablesaw.plotly.api;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.plotly.components.Figure;
+import tech.tablesaw.plotly.components.Layout;
 import tech.tablesaw.plotly.traces.TreemapTrace;
 
 public class TreemapPlot {
 
     /**
-     *
-     * @param title
-     * @param table
-     * @param col
-     * @param parentCol the parent column, which is assumed to be a separate list of entities compared to `col`.
-     * @return
+     * @param col the labels column name
+     * @param parentCol the parent column name
      */
     public static Figure create(String title, Table table, String col, String parentCol) {
         Object[] children = table.column(col).asObjectArray();
         Object[] parents = table.column(parentCol).asObjectArray();
 
-        Object[] labels = new Object[children.length + parents.length];
+        Set<?> uniqueParents = new HashSet<>(Arrays.asList(parents));
+        uniqueParents.removeAll(Arrays.asList(children));
+
+        Object[] labels = new Object[children.length + uniqueParents.size()];
 
         //fill labels with both children and parents
         System.arraycopy(children, 0, labels, 0, children.length);
-        System.arraycopy(parents, 0, labels, children.length, parents.length);
+        System.arraycopy(uniqueParents.toArray(), 0, labels, children.length, uniqueParents.size());
 
         Object[] labelParents = new Object[labels.length];
         System.arraycopy(parents, 0, labelParents, 0, parents.length);
         //other labels are empty
         Arrays.fill(labelParents, parents.length, labelParents.length, "");
 
+        return create(title, labels, labelParents);
+    }
+
+    public static Figure create(String title, Object[] labels, Object[] labelParents) {
         TreemapTrace trace = TreemapTrace.builder(
                 labels,
                 labelParents)
                 .build();
-        return new Figure(trace);
+        return new Figure(Layout.builder(title).build(), trace);
     }
+
 }

--- a/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
+++ b/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
@@ -39,7 +39,7 @@ public class ChartsTreemap extends AbstractComponentsChartsPage {
         Table treemapTable = TSDataSetFactory.createSampleStockMarketEquities().getTSTable();
 
         body.addRowOfColumns(
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv1", "Sector", "Company", 900, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv1", "Company", "Sector", 900, 200, false) ,
                         "Treemap Chart")
         );
 
@@ -53,11 +53,11 @@ public class ChartsTreemap extends AbstractComponentsChartsPage {
         );
 
         body.addRowOfColumns(
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv4", "Sector", "Company", 300, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv4", "Company", "Sector", 300, 200, false) ,
                         "Treemap Chart"),
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv5", "Sector", "Company", 300, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv5", "Company", "Sector", 300, 200, false) ,
                         "Treemap Chart"),
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv6", "Sector", "Company", 300, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv6", "Company", "Sector", 300, 200, false) ,
                         "Treemap Chart")
         );
 

--- a/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
+++ b/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
@@ -43,10 +43,12 @@ public class ChartsTreemap extends AbstractComponentsChartsPage {
                         "Treemap Chart")
         );
 
+        Table bsdTable = TSDataSetFactory.createSampleFamilyTreeData().getTSTable();
+
         body.addRowOfColumns(
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv2", "Sector", "Company", 450, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(bsdTable, "treemapDiv2", "Name", "Parent", 450, 200, false) ,
                         "Treemap Chart"),
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv3", "Sector", "Company", 450, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(bsdTable, "treemapDiv3", "Name", "Parent", 450, 200, false) ,
                         "Treemap Chart")
         );
 


### PR DESCRIPTION
* adds a 'family tree' BSD demo to see what happens when the parent column has items from  the children column (ie. they are not a separate category)
* only adds unique parent names to Plotly labels list
* swaps "Company" with "Sector" in the demo