### PR TITLE
Builds treemap based on multiple columns

### DIFF
--- a/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/charts/TSTreeMapChartPanel.java
+++ b/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/charts/TSTreeMapChartPanel.java
@@ -22,13 +22,13 @@ import tech.tablesaw.plotly.components.Figure;
 
 public class TSTreeMapChartPanel extends TSFigurePanel {
 
-    public TSTreeMapChartPanel(Table table, String divName, String col, String parentCol, int width, int height, boolean enableLegend) {
+    public TSTreeMapChartPanel(Table table, String divName, int width, int height, boolean enableLegend, String... columns) {
         super(divName);
 
         Figure figure = null;
 
         try {
-            figure = TreemapPlot.create("", table, col, parentCol);
+            figure = TreemapPlot.create("", table, columns);
         } catch ( Exception e ) {
             e.printStackTrace();
         }

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/TreemapPlot.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/TreemapPlot.java
@@ -1,9 +1,11 @@
 package tech.tablesaw.plotly.api;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
+import java.util.TreeMap;
+import tech.tablesaw.api.Row;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.plotly.components.Figure;
 import tech.tablesaw.plotly.components.Layout;
@@ -12,26 +14,30 @@ import tech.tablesaw.plotly.traces.TreemapTrace;
 public class TreemapPlot {
 
     /**
-     * @param col the labels column name
-     * @param parentCol the parent column name
+     * @param cols the columns in hierarchy order (smallest element first,
+     * parent last)
      */
-    public static Figure create(String title, Table table, String col, String parentCol) {
-        Object[] children = table.column(col).asObjectArray();
-        Object[] parents = table.column(parentCol).asObjectArray();
+    public static Figure create(String title, Table table, String... cols) {
+        if (cols.length < 2) {
+            throw new IllegalStateException("At least two columns needed");
+        }
+        //it's important the (child, parent) pairs map is sorted to build the list more easily later on
+        TreeMap<String, String> pairs = pairs(table, cols);
+        Set<String> children = pairs.keySet();
+        Collection<String> parents = pairs.values();
 
-        Set<?> uniqueParents = new HashSet<>(Arrays.asList(parents));
-        uniqueParents.removeAll(Arrays.asList(children));
+        Set<String> uniqueParents = new HashSet<>(parents);
+        uniqueParents.removeAll(children);
 
-        Object[] labels = new Object[children.length + uniqueParents.size()];
-
+        Object[] labels = new Object[children.size() + uniqueParents.size()];
         //fill labels with both children and parents
-        System.arraycopy(children, 0, labels, 0, children.length);
-        System.arraycopy(uniqueParents.toArray(), 0, labels, children.length, uniqueParents.size());
+        children.toArray(labels);
+        System.arraycopy(uniqueParents.toArray(), 0, labels, children.size(), uniqueParents.size());
 
         Object[] labelParents = new Object[labels.length];
-        System.arraycopy(parents, 0, labelParents, 0, parents.length);
+        parents.toArray(labelParents);
         //other labels are empty
-        Arrays.fill(labelParents, parents.length, labelParents.length, "");
+        Arrays.fill(labelParents, parents.size(), labelParents.length, "");
 
         return create(title, labels, labelParents);
     }
@@ -42,6 +48,21 @@ public class TreemapPlot {
                 labelParents)
                 .build();
         return new Figure(Layout.builder(title).build(), trace);
+    }
+
+    private static TreeMap<String, String> pairs(Table table, String... cols) {
+        TreeMap<String, String> pairs = new TreeMap<>();
+
+        for (Row row : table) {
+            String child = row.getString(cols[0]);
+            for (int i = 1; i < cols.length; i++) {
+                String parent = row.getString(cols[i]);
+                pairs.put(child, parent);
+                child = parent;
+            }
+        }
+
+        return pairs;
     }
 
 }

--- a/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/Charts.java
+++ b/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/Charts.java
@@ -95,7 +95,7 @@ public class Charts extends AbstractComponentsChartsPage {
         body.addRowOfColumns(
                 new BSCard(new TSHistogramChartPanel(histogramTable, "histogramDiv", "Population", 500, 200, false) ,
                         "Histogram Chart"),
-                new BSCard(new TSHeatMapChartPanel(heatmapTable, "heatmapDiv", "Sector", "Company", 500, 200, false) ,
+                new BSCard(new TSHeatMapChartPanel(heatmapTable, "heatmapDiv", "Company", "Sector", 500, 200, false) ,
                         "Heatmap Chart")
         );
 
@@ -117,7 +117,7 @@ public class Charts extends AbstractComponentsChartsPage {
         Table sunburstTable = stockEquitiesTable;
 
         body.addRowOfColumns(
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv", "Sector", "Company", 500, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv", 500, 200, false, "Company", "Sector") ,
                         "Treemap Chart"),
                 new BSCard(new TSSunburstChartPanel(sunburstTable, "sunburstDiv", "Company", "MarketCap", 500, 200, false) ,
                         "Sunburst Chart")

--- a/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
+++ b/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
@@ -39,25 +39,25 @@ public class ChartsTreemap extends AbstractComponentsChartsPage {
         Table treemapTable = TSDataSetFactory.createSampleStockMarketEquities().getTSTable();
 
         body.addRowOfColumns(
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv1", "Company", "Sector", 900, 200, true) ,
+                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv1", 900, 200, true, "Company", "Industry", "Sector") ,
                         "Treemap Chart")
         );
 
         Table bsdTable = TSDataSetFactory.createSampleFamilyTreeData().getTSTable();
 
         body.addRowOfColumns(
-                new BSCard(new TSTreeMapChartPanel(bsdTable, "treemapDiv2", "Name", "Parent", 450, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(bsdTable, "treemapDiv2", 450, 200, false, "Name", "Parent") ,
                         "Treemap Chart"),
-                new BSCard(new TSTreeMapChartPanel(bsdTable, "treemapDiv3", "Name", "Parent", 450, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(bsdTable, "treemapDiv3", 450, 200, false, "Name", "Parent") ,
                         "Treemap Chart")
         );
 
         body.addRowOfColumns(
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv4", "Company", "Sector", 300, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv4", 300, 200, false, "Company", "Sector") ,
                         "Treemap Chart"),
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv5", "Company", "Sector", 300, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv5", 300, 200, false, "Company", "Sector") ,
                         "Treemap Chart"),
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv6", "Company", "Sector", 300, 200, false) ,
+                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv6", 300, 200, false, "Company", "Sector") ,
                         "Treemap Chart")
         );
 


### PR DESCRIPTION
`TreemapPlot.create` now accepts a list of columns (in hierarchical order).

Had to move the column list vararg at the end of the constructor argument list.