### PR TITLE
Sets layout in TreemapPlot, displays more data in the stock market tree map

### DIFF
--- a/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/charts/TSTreeMapChartPanel.java
+++ b/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/charts/TSTreeMapChartPanel.java
@@ -19,6 +19,8 @@ package quicksilver.webapp.simpleui.bootstrap4.charts;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.plotly.api.TreemapPlot;
 import tech.tablesaw.plotly.components.Figure;
+import tech.tablesaw.plotly.components.Layout;
+import tech.tablesaw.plotly.components.Margin;
 
 public class TSTreeMapChartPanel extends TSFigurePanel {
 
@@ -28,7 +30,22 @@ public class TSTreeMapChartPanel extends TSFigurePanel {
         Figure figure = null;
 
         try {
-            figure = TreemapPlot.create("", table, columns);
+            //default margins are huge for small dimensions. leave 10% each side but no more than 50px
+            int margin = Math.min(50, Math.min(width, height) / 10);
+
+            figure = TreemapPlot.create(
+                    Layout.builder("")
+                            .width(width)
+                            .height(height)
+                            .margin(Margin.builder()
+                                    .top(margin)
+                                    .bottom(margin)
+                                    .left(margin)
+                                    .right(margin)
+                                    .build())
+                            .showLegend(enableLegend)
+                            .build(),
+                    table, columns);
         } catch ( Exception e ) {
             e.printStackTrace();
         }

--- a/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
+++ b/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
@@ -45,7 +45,7 @@ public class ChartsTreemap extends AbstractComponentsChartsPage {
         try {
             InputStream inputStream = getClass().getResourceAsStream("stocks.csv");
             treemapTable = Table.read().csv(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-            treemapTable = treemapTable.sampleN(10);
+            treemapTable = treemapTable.sampleN(100);
 
             //System.out.println(treemapTable.structure());
 
@@ -55,7 +55,7 @@ public class ChartsTreemap extends AbstractComponentsChartsPage {
         }
 
         body.addRowOfColumns(
-                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv1", 900, 200, true, "Company", "Industry", "Sector"),
+                new BSCard(new TSTreeMapChartPanel(treemapTable, "treemapDiv1", 900, 400, true, "Company", "Industry", "Sector"),
                         "Treemap Chart")
         );
 


### PR DESCRIPTION
Loading just 100 entries from the stock market but all can be loaded (albeit a bit slowly imho).

I'm not entirely sure why Plot.ly uses the space allocated so badly. Seems to try square-ish treemaps instead of using all the width.

There was also a cycle in the CSV: Conglomerates->Conglomerates.