### PR TITLE
Adds treemap color

### DIFF
--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/traces/TreemapTrace.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/traces/TreemapTrace.java
@@ -53,8 +53,22 @@ public class TreemapTrace extends AbstractTrace {
         }
         context.put("labels", dataAsString(labels));
         context.put("parents", dataAsString(parents));
-        if(extra!=null) {
-            extra.forEach((k, array) -> context.put(k, dataAsString(array)));
+        if (extra != null) {
+            extra.forEach((k, array) -> {
+                if (!k.contains(".")) {
+                    context.put(k, dataAsString(array));
+                }
+            });
+            extra.forEach((k, array) -> {
+                if (k.equals("marker.colors")) {
+                    //Marker.color generates color: not colors: so we manually generate the JS
+                    context.put("marker", "{\ncolors : " + dataAsString(array) + "\n}");
+//                    context.put("marker", Marker.builder()
+//                            .color(
+//                                    Stream.of((Object[]) array).map(x -> String.valueOf(x)).toArray(String[]::new))
+//                            .build());
+                }
+            });
         }
         return context;
     }


### PR DESCRIPTION
This adds red/green color to the individual ticker cell but it's not smart enough to add color for aggregates.

Note that creating marker.colors was impossible with the existing APIs. Tablesaw has `marker.color` which can be a color array but for some reason treemap expects `colors`. Odd.

BTW, leaving the color blank for industry/sector does make Plot.ly add their color palette but it looks odd next to the red/green. Maybe some toned down color palette exists which looks good combined. The muted gray isn't pretty but better than nothing.