### PR TITLE
Lets Plotly draw the color via marker.colors array and a custom colorscale:

### DIFF
--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/traces/TreemapTrace.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/traces/TreemapTrace.java
@@ -6,8 +6,12 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Map;
+import java.util.stream.Stream;
 import tech.tablesaw.columns.Column;
 import static tech.tablesaw.plotly.Utils.dataAsString;
+import tech.tablesaw.plotly.components.ColorBar;
+import tech.tablesaw.plotly.components.Marker;
+import tech.tablesaw.plotly.components.TickSettings;
 
 public class TreemapTrace extends AbstractTrace {
 
@@ -62,11 +66,26 @@ public class TreemapTrace extends AbstractTrace {
             extra.forEach((k, array) -> {
                 if (k.equals("marker.colors")) {
                     //Marker.color generates color: not colors: so we manually generate the JS
-                    context.put("marker", "{\ncolors : " + dataAsString(array) + "\n}");
-//                    context.put("marker", Marker.builder()
-//                            .color(
-//                                    Stream.of((Object[]) array).map(x -> String.valueOf(x)).toArray(String[]::new))
-//                            .build());
+//                    context.put("marker", "{\ncolors : " + dataAsString(array) + "\n}");
+                    Marker m = Marker.builder()
+                            .colorScale(Marker.Palette.YL_OR_RD)
+                            .color(
+                                    Stream.of((Object[]) array).map(x -> String.valueOf(x)).toArray(String[]::new))
+                            .colorBar(ColorBar.builder()
+                                    .tickSettings(TickSettings.builder()
+                                            .dTick("1")
+                                            .tick0("0")
+                                            .build())
+                                    .build())
+                            .build();
+                    String markerJS = m.asJavascript();
+                    //XXX: The colorscale: here might be too specific
+                    markerJS = markerJS.replace("color:", "colors:");
+                    markerJS = markerJS.replace("colorscale: 'YlOrRd'", "colorscale: [\n"
+                            + "        ['0.0', 'rgb(255,0,0)'],\n"
+                            + "        ['1.0', 'rgb(0,255,0)']\n"
+                            + "    ]");
+                    context.put("marker", markerJS);
                 }
             });
         }

--- a/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
+++ b/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
@@ -160,7 +160,7 @@ public class ChartsTreemap extends AbstractComponentsChartsPage {
                                 .layout(layoutBuilder.build())
                                 .addAttribute("text", "Change", "")
                                 .addAttribute("values", "MarketCap", 0d)
-                                .addAttribute("marker.colors", "Color", "#7f7f7f")
+                                .addAttribute("marker.colors", "ChangeAsNumber", 0d)
                                 .build(),
                         "Treemap Chart")
         );


### PR DESCRIPTION
This seems a better way to set the color as Plot.ly computes it from ticker change values.

This PR also sets the color bar.

Note that TreemapTrace marker is a bit too specific for our needs. I haven't look at making a proper API for all that.

Also note how the Marker JS conversion has two issues: `color -> colors` and the lack of a custom `colorscale`.