### PR TITLE
Opens ticker URL on treemap double-click

### DIFF
--- a/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/charts/TSTreeMapChartPanel.java
+++ b/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/charts/TSTreeMapChartPanel.java
@@ -16,8 +16,10 @@
 
 package quicksilver.webapp.simpleui.bootstrap4.charts;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import quicksilver.webapp.simpleui.html.components.HTMLText;
 import tech.tablesaw.api.Table;
@@ -25,6 +27,7 @@ import tech.tablesaw.plotly.api.TreemapPlot;
 import tech.tablesaw.plotly.components.Figure;
 import tech.tablesaw.plotly.components.Layout;
 import tech.tablesaw.plotly.components.Margin;
+import tech.tablesaw.plotly.event.EventHandler;
 
 public class TSTreeMapChartPanel extends TSFigurePanel {
 
@@ -57,19 +60,20 @@ public class TSTreeMapChartPanel extends TSFigurePanel {
     private TSTreeMapChartPanel(Builder builder) {
         this(builder.layout, builder.table, builder.divName,
                 builder.familyTree ? ColumnRelation.FamilyTree : ColumnRelation.SubCategories,
-                builder.columns, new HashMap<>(builder.attributes), new HashMap<>(builder.attributeDefaults));
+                builder.columns, new HashMap<>(builder.attributes), new HashMap<>(builder.attributeDefaults),
+                builder.eventHandlers.toArray(new EventHandler[0]));
     }
 
     public TSTreeMapChartPanel(Layout layout, Table table, String divName, String... columns) {
-        this(layout, table, divName, ColumnRelation.SubCategories, columns, Collections.EMPTY_MAP,  Collections.EMPTY_MAP);
+        this(layout, table, divName, ColumnRelation.SubCategories, columns, Collections.EMPTY_MAP,  Collections.EMPTY_MAP, new EventHandler[0]);
     }
 
-    private TSTreeMapChartPanel(Layout layout, Table table, String divName, ColumnRelation relationship, String[] columns, Map<String, String> attColumns, Map<String, Object> attDefaults) {
+    private TSTreeMapChartPanel(Layout layout, Table table, String divName, ColumnRelation relationship, String[] columns, Map<String, String> attColumns, Map<String, Object> attDefaults, EventHandler[] handlers) {
         super(divName);
 
         Figure figure = null;
         try {
-            figure = TreemapPlot.create(layout, table, relationship == ColumnRelation.FamilyTree, columns, attColumns, attDefaults);
+            figure = TreemapPlot.create(layout, table, relationship == ColumnRelation.FamilyTree, columns, attColumns, attDefaults, handlers);
         } catch ( Exception e ) {
             e.printStackTrace();
         }
@@ -82,7 +86,7 @@ public class TSTreeMapChartPanel extends TSFigurePanel {
     }
 
     public TSTreeMapChartPanel(Table table, String divName, int width, int height, boolean enableLegend, String... columns) {
-        this(defaultLayout(width, height, enableLegend), table, divName, ColumnRelation.SubCategories, columns, Collections.EMPTY_MAP, Collections.EMPTY_MAP);
+        this(defaultLayout(width, height, enableLegend), table, divName, ColumnRelation.SubCategories, columns, Collections.EMPTY_MAP, Collections.EMPTY_MAP, new EventHandler[0]);
     }
 
     public static Layout.LayoutBuilder createLayoutBuilder(int width, int height, boolean enabledLegend) {
@@ -102,6 +106,7 @@ public class TSTreeMapChartPanel extends TSFigurePanel {
         private boolean familyTree;
         private final Map<String, String> attributes = new HashMap<>();
         private final Map<String, Object> attributeDefaults = new HashMap<>();
+        private List<EventHandler> eventHandlers = new ArrayList<>();
 
         private Builder(Table table, String divName, String[] columns) {
             this.table = table;
@@ -122,6 +127,11 @@ public class TSTreeMapChartPanel extends TSFigurePanel {
         public Builder addAttribute(String attribute, String column, Object defaultValue) {
             attributes.put(attribute, column);
             attributeDefaults.put(attribute, defaultValue);
+            return this;
+        }
+
+        public Builder addEventHandler(EventHandler e) {
+            eventHandlers.add(e);
             return this;
         }
 

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/TreemapPlot.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/TreemapPlot.java
@@ -4,24 +4,25 @@ import java.util.Map;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.plotly.components.Figure;
 import tech.tablesaw.plotly.components.Layout;
+import tech.tablesaw.plotly.event.EventHandler;
 import tech.tablesaw.plotly.traces.TreemapTrace;
 
 public class TreemapPlot {
 
     public static Figure create(String title, Table table, boolean familyTree, String[] cols, Map<String, String> attCols, Map<String, Object> attDefaults) {
-        return create(Layout.builder(title).build(), table, familyTree, cols, attCols, attDefaults);
+        return create(Layout.builder(title).build(), table, familyTree, cols, attCols, attDefaults, new EventHandler[0]);
     }
 
     /**
      * @param cols the columns in hierarchy order (smallest element first,
      * parent last)
      */
-    public static Figure create(Layout layout, Table table, boolean familyTree, String[] cols, Map<String, String> attCols, Map<String, Object> attDefaults) {
+    public static Figure create(Layout layout, Table table, boolean familyTree, String[] cols, Map<String, String> attCols, Map<String, Object> attDefaults, EventHandler[] handlers) {
         Extract.TableInfo info = Extract.createPairs(table, familyTree, cols, attCols, attDefaults);
         Object[] labels = info.labels;
         Object[] labelParents = info.labelParents;
 
-        return create(layout, info.ids, labels, labelParents, info.attributeLists);
+        return create(layout, info.ids, labels, labelParents, info.attributeLists, handlers);
     }
 
     public static Figure create(String title, String[] ids, Object[] labels, Object[] labelParents) {
@@ -29,6 +30,11 @@ public class TreemapPlot {
     }
 
     public static Figure create(Layout layout, String[] ids, Object[] labels, Object[] labelParents, Map<String, Object[]> extra) {
+        return create(layout, ids, labels, labelParents, extra, new EventHandler[0]);
+    }
+
+    public static Figure create(Layout layout, String[] ids, Object[] labels, Object[] labelParents, Map<String, Object[]> extra,
+            EventHandler[] handlers) {
         sanitize(labels);
         sanitize(labelParents);
         TreemapTrace trace = TreemapTrace.builder(
@@ -37,7 +43,11 @@ public class TreemapPlot {
                 labelParents,
                 extra)
                 .build();
-        return new Figure(layout, trace);
+        Figure.FigureBuilder builder = Figure.builder()
+                .layout(layout)
+                .addTraces(trace)
+                .addEventHandlers(handlers);
+        return builder.build();
     }
 
     //see https://github.com/jtablesaw/tablesaw/pull/699

--- a/simple-web-ui-toolkit/src/main/resources/trace_template2.html
+++ b/simple-web-ui-toolkit/src/main/resources/trace_template2.html
@@ -94,6 +94,9 @@ parents: {{parents | raw}},
 {% if values is not null %}
 values: {{values | raw}},
 {% endif %}
+{% if urls is not null %}
+urls: {{urls | raw}},
+{% endif %}
 type: '{{type}}',
 name: '{{name}}',
 };

--- a/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
+++ b/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsTreemap.java
@@ -35,6 +35,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
+import tech.tablesaw.plotly.event.EventHandler;
 
 public class ChartsTreemap extends AbstractComponentsChartsPage {
 
@@ -162,6 +163,47 @@ public class ChartsTreemap extends AbstractComponentsChartsPage {
                                 .addAttribute("text", "Change", "")
                                 .addAttribute("values", "MarketCap", 0d)
                                 .addAttribute("marker.colors", "ChangeAsNumber", 0d)
+                                //XXX: urls: is not a proper field... Not sure how to add extra data which will be available to the handler
+                                .addAttribute("urls", "Ticker", "")
+                                .addEventHandler(new EventHandler() {
+                                    @Override
+                                    public String asJavascript(String targetName, String divName) {
+                                        return "var clickCounter = 0;\n"
+                                                + "var timer = null;\n"
+                                                + "var timerURL = null;\n"
+                                                + targetName + ".on('plotly_treemapclick', function(data) {\n"
+                                                + "  var key = data.points[0].id;\n"
+                                                + "  var data = data.points[0].data;\n"
+                                                + "  var index = data.ids.indexOf(key);\n"
+                                                + "  var targetURL = data.urls[index];\n"
+                                                + "  //console.log(key + \"-\" + data.urls[index]);\n"
+                                                + "  //console.log(data);\n"
+                                                + "  clickCounter++;\n"
+                                                + "  if(clickCounter == 2) {\n"
+                                                + "    if(targetURL != timerURL) {\n"
+                                                + "      //restart counter for this url/cell which will also clear previous timer out\n"
+                                                + "      clickCounter = 1;\n"
+                                                + "    }\n"
+                                                + "  }\n"
+                                                + "  timerURL = targetURL;\n"
+                                                + "  if(clickCounter == 1) {\n"
+                                                + "   if(timer != null) {\n"
+                                                + "     clearTimeout(timer);\n"
+                                                + "   }\n"
+                                                + "   if (timerURL === undefined || timerURL=='') {\n"
+                                                + "     clickCounter = 0;\n"
+                                                + "     return;\n"
+                                                + "   }\n"
+                                                + "   timer = setTimeout(function() {\n"
+                                                + "     if(clickCounter == 2) {\n"
+                                                + "       window.location = 'quote?ticker='+timerURL;\n"
+                                                + "     }\n"
+                                                + "     clickCounter=0;\n"
+                                                + "   }, 500 /*ms*/);\n"
+                                                + "  }\n"
+                                                + "});";
+                                    }
+                                })
                                 .build(),
                         "Treemap Chart")
         );


### PR DESCRIPTION
This opens `components/charts/quote?ticker=xxx` for the clicked ticker cell. Note there is no handler for `quote` so it will 404.

I've forced the `urls:` field in the template to have a clean list. I could have also used `labels:` in the event handler although then it would have allowed double-click on sectors/industry too.

There's no double-click handler so I have to manually count clicks...

Part of issue #36 