### PR TITLE
Opens company URL on sunburst double-click

### DIFF
--- a/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/charts/TSSunburstChartPanel.java
+++ b/simple-web-ui-toolkit/src/main/java/quicksilver/webapp/simpleui/bootstrap4/charts/TSSunburstChartPanel.java
@@ -21,16 +21,22 @@ import tech.tablesaw.api.Table;
 import tech.tablesaw.plotly.api.SunburstPlot;
 import tech.tablesaw.plotly.components.Figure;
 import tech.tablesaw.plotly.components.Layout;
+import tech.tablesaw.plotly.event.EventHandler;
 
 public class TSSunburstChartPanel extends TSFigurePanel {
 
     public TSSunburstChartPanel(Layout layout, Table table, String divName, String... columns) {
+        this(layout, table, divName, null, columns);
+    }
+
+    public TSSunburstChartPanel(Layout layout, Table table, String divName, EventHandler handler, String... columns) {
         super(divName);
 
         Figure figure = null;
 
         try {
-            figure = SunburstPlot.create(layout, table, columns);
+            EventHandler[] handlers = (handler == null) ? new EventHandler[0] : new EventHandler[]{handler};
+            figure = SunburstPlot.create(layout, table, handlers, columns);
         } catch ( Exception e ) {
             e.printStackTrace();
         }
@@ -48,7 +54,7 @@ public class TSSunburstChartPanel extends TSFigurePanel {
         Figure figure = null;
 
         try {
-            figure = SunburstPlot.create(TSTreeMapChartPanel.defaultLayout(width, height, enableLegend), table, columns);
+            figure = SunburstPlot.create(TSTreeMapChartPanel.defaultLayout(width, height, enableLegend), table, new EventHandler[0], columns);
         } catch ( Exception e ) {
             e.printStackTrace();
         }

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/SunburstPlot.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/SunburstPlot.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.plotly.components.Figure;
 import tech.tablesaw.plotly.components.Layout;
+import tech.tablesaw.plotly.event.EventHandler;
 import tech.tablesaw.plotly.traces.SunburstTrace;
 
 public class SunburstPlot {
@@ -14,11 +15,15 @@ public class SunburstPlot {
         return create(Layout.builder(title).build(), table, cols);
     }
 
+    public static Figure create(Layout layout, Table table, String... cols) {
+        return create(layout, table, new EventHandler[0], cols);
+    }
+
     /**
      * @param cols the columns in hierarchy order (smallest element first,
      * parent last). Last column is the numeric value.
      */
-    public static Figure create(Layout layout, Table table, String... cols) {
+    public static Figure create(Layout layout, Table table, EventHandler[] handlers, String... cols) {
         //TODO: Support if(cols.length == 2)
         if (cols.length < 3) {
             throw new IllegalStateException("At least three columns needed");
@@ -32,14 +37,14 @@ public class SunburstPlot {
         Object[] labelParents = info.labelParents;
         double[] values = Stream.of(info.attributeLists.get("values")).mapToDouble(o -> ((Double)o)).toArray();
 
-        return create(layout, info.ids, labels, labelParents, values);
+        return create(layout, info.ids, labels, labelParents, values, handlers);
     }
 
     public static Figure create(String title, String[] ids, Object[] labels, Object[] labelParents, double[] values) {
-        return create(Layout.builder(title).build(), ids, labels, labelParents, values);
+        return create(Layout.builder(title).build(), ids, labels, labelParents, values, new EventHandler[0]);
     }
 
-    public static Figure create(Layout layout, String[] ids, Object[] labels, Object[] labelParents, double[] values) {
+    public static Figure create(Layout layout, String[] ids, Object[] labels, Object[] labelParents, double[] values, EventHandler[] handlers) {
         TreemapPlot.sanitize(labels);
         TreemapPlot.sanitize(labelParents);
         SunburstTrace trace = SunburstTrace.builder(
@@ -48,7 +53,11 @@ public class SunburstPlot {
                 labelParents,
                 values)
                 .build();
-        return new Figure(layout, trace);
+        Figure.FigureBuilder builder = Figure.builder()
+                .layout(layout)
+                .addTraces(trace)
+                .addEventHandlers(handlers);
+        return builder.build();
     }
 
 }

--- a/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsSunburst.java
+++ b/simple-webserver/src/main/java/quicksilver/webapp/simpleserver/controllers/root/components/charts/ChartsSunburst.java
@@ -16,6 +16,9 @@
 
 package quicksilver.webapp.simpleserver.controllers.root.components.charts;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
 import quicksilver.commons.data.TSDataSetFactory;
 import quicksilver.webapp.simpleui.bootstrap4.charts.TSSunburstChartPanel;
 import quicksilver.webapp.simpleui.bootstrap4.components.BSCard;
@@ -30,6 +33,14 @@ public class ChartsSunburst extends AbstractComponentsChartsPage {
     public ChartsSunburst() {
         super();
         toolbar.setActiveButton("Sunburst");
+    }
+
+    private static String resource(String name, String def) {
+        try {
+            return IOUtils.toString(ChartsSunburst.class.getResourceAsStream(name), StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            return def;
+        }
     }
 
     protected BSPanel createContentPanelCenter() {
@@ -49,7 +60,12 @@ public class ChartsSunburst extends AbstractComponentsChartsPage {
         Layout layout = layoutBuilder.build();
 
         body.addRowOfColumns(
-                new BSCard(new TSSunburstChartPanel(layout, sunburstTable, "sunburstDiv1", "Company", "Industry", "Sector", "MarketCap") ,
+                new BSCard(new TSSunburstChartPanel(layout, sunburstTable, "sunburstDiv1",
+                        (String targetName, String divName) -> {
+                            return resource("sunburst-doubleclick-handler.js", "")
+                                    .replaceAll("targetName", targetName);
+                        },
+                        "Company", "Industry", "Sector", "MarketCap"),
                         "Sunburst Chart")
         );
 

--- a/simple-webserver/src/main/resources/quicksilver/webapp/simpleserver/controllers/root/components/charts/sunburst-doubleclick-handler.js
+++ b/simple-webserver/src/main/resources/quicksilver/webapp/simpleserver/controllers/root/components/charts/sunburst-doubleclick-handler.js
@@ -1,0 +1,35 @@
+var clickCounter = 0;
+var timer = null;
+var timerURL = null;
+
+targetName.on('plotly_sunburstclick', function (data) {
+    var key = data.points[0].id;
+    var data = data.points[0].data;
+    var index = data.ids.indexOf(key);
+    var targetURL = data.labels[index];
+    //console.log(key + "-" + targetURL);
+    //console.log(data);
+    clickCounter++;
+    if (clickCounter == 2) {
+        if (targetURL != timerURL) {
+            //restart counter for this url/cell which will also clear previous timer out
+            clickCounter = 1;
+        }
+    }
+    timerURL = targetURL;
+    if (clickCounter == 1) {
+        if (timer != null) {
+            clearTimeout(timer);
+        }
+        if (timerURL === undefined || timerURL == '') {
+            clickCounter = 0;
+            return;
+        }
+        timer = setTimeout(function () {
+            if (clickCounter == 2) {
+                window.location = 'quote?ticker=' + timerURL;
+            }
+            clickCounter = 0;
+        }, 500 /*ms*/);
+    }
+});


### PR DESCRIPTION
This is almost the same as the treemap double-click code.

Due to the way the demo chart is made (no ticker text) double-clicking uses the label text to build an URL.

For readability the Javascript chunk is a separate .js file which is slightly tweaked.

The SunburstPlot methods are starting to look unwieldy with all the parameters. Will have to revisit for a cleanup perhaps before doing a PR to Tablesaw. 

Closes issue #36