### PR TITLE
Sets the bar chart mode (stack, group, overlay) based on the chartType option

### DIFF
--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/ChartBuilder.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/ChartBuilder.java
@@ -41,6 +41,7 @@ public abstract class ChartBuilder {
 
     protected Table dataTable;
     protected CHART_TYPE chartType;
+    protected Object[] chartTypeOptions;
     protected Layout layout;
     protected String divName;
     protected String[] columnsForViewColumns;
@@ -96,8 +97,9 @@ public abstract class ChartBuilder {
         return this;
     }
 
-    public ChartBuilder chartType(CHART_TYPE chartType) {
+    public ChartBuilder chartType(CHART_TYPE chartType, Object... chartTypeOptions) {
         this.chartType = chartType;
+        this.chartTypeOptions = chartTypeOptions;
         return this;
     }
 

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/PlotlyChartBuilder.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/PlotlyChartBuilder.java
@@ -12,6 +12,7 @@ import tech.tablesaw.plotly.api.SunburstPlot;
 import tech.tablesaw.plotly.api.TableExtract;
 import tech.tablesaw.plotly.api.TreemapPlot;
 import tech.tablesaw.plotly.components.Figure;
+import tech.tablesaw.plotly.components.Layout;
 import tech.tablesaw.plotly.event.EventHandler;
 
 public class PlotlyChartBuilder extends ChartBuilder {
@@ -36,7 +37,7 @@ public class PlotlyChartBuilder extends ChartBuilder {
                 layout(width, height, 5, 20, 35, 20, enabledLegend);
                 break;
             case HORIZONTAL_BAR:
-                layout(width, height, 5, 20, 55, 5, enabledLegend);
+                layoutHorizontalBar(width, height, enabledLegend);
                 break;
             case LINE:
                 layout(width, height, 5, 20, 35, 5, enabledLegend);
@@ -60,7 +61,7 @@ public class PlotlyChartBuilder extends ChartBuilder {
                 layout(width, height, 0, 0, 0, 0, enabledLegend);
                 break;
             case VERTICAL_BAR:
-                layout(width, height, 5, 40, 35, 5, enabledLegend);
+                layoutVerticalBar(width, height, enabledLegend);
                 break;
             default:
                 layout(width, height, 0, 0, 0, 0, enabledLegend);
@@ -276,6 +277,24 @@ public class PlotlyChartBuilder extends ChartBuilder {
         } catch ( Exception e ) {
             e.printStackTrace();
             return null;
+        }
+    }
+
+    private void layoutHorizontalBar(int width, int height, boolean enabledLegend) {
+        layout(width, height, 5, 20, 55, 5, enabledLegend);
+        configureLayoutBuilderBarMode();
+    }
+
+    private void layoutVerticalBar(int width, int height, boolean enabledLegend) {
+        layout(width, height, 5, 40, 35, 5, enabledLegend);
+        configureLayoutBuilderBarMode();
+    }
+
+    private void configureLayoutBuilderBarMode() {
+        for (Object o : chartTypeOptions) {
+            if (o instanceof Layout.BarMode) {
+                layoutBuilder.barMode((Layout.BarMode) o);
+            }
         }
     }
 


### PR DESCRIPTION
I have been thinking how to support these chart-specific options.

We don't have a good dataset to showcase a stacked bar chart but API-wise it could look like this:

```java
        ChartBuilder vbarChartBuilder = ChartBuilder.createBuilder()
                .dataTable(hBarTable)
                .chartType(ChartBuilder.CHART_TYPE.VERTICAL_BAR, Layout.BarMode.STACK)
                .columnsForViewColumns("Country")
                .columnsForViewRows("GDP", "Population")
```

It's a bit crude to just pile up Object attributes but I'm not certain how to do it otherwise since ChartBuilder is supposed to work on all charts.