### PR TITLE
Line and time series plot color column, time series, OHLC and candlestick trace colors

### DIFF
--- a/quicksaw-charts/src/main/java/tech/tablesaw/plotly/components/change/Change.java
+++ b/quicksaw-charts/src/main/java/tech/tablesaw/plotly/components/change/Change.java
@@ -3,6 +3,7 @@ package tech.tablesaw.plotly.components.change;
 import java.util.HashMap;
 import java.util.Map;
 import tech.tablesaw.plotly.components.Component;
+import tech.tablesaw.plotly.components.Line;
 
 public abstract class Change extends Component {
 
@@ -10,6 +11,7 @@ public abstract class Change extends Component {
 
   private final ChangeLine changeLine;
   private final String fillColor;
+  private final Line line;
 
   @Override
   public String asJavascript() {
@@ -19,6 +21,7 @@ public abstract class Change extends Component {
   Change(ChangeBuilder builder) {
     this.changeLine = builder.changeLine;
     this.fillColor = builder.fillColor;
+    this.line = builder.line;
   }
 
   @Override
@@ -26,16 +29,23 @@ public abstract class Change extends Component {
     Map<String, Object> context = new HashMap<>();
     if (changeLine != null) context.put("changeLine", changeLine);
     if (fillColor != null) context.put("fillColor", fillColor);
+    if (line != null) context.put("line", line.asJavascript());
     return context;
   }
 
   public static class ChangeBuilder {
 
     protected String fillColor;
+    protected Line line;
     protected ChangeLine changeLine;
 
     public ChangeBuilder fillColor(String color) {
       this.fillColor = color;
+      return this;
+    }
+
+    public ChangeBuilder line(Line line) {
+      this.line = line;
       return this;
     }
 

--- a/quicksaw-charts/src/main/java/tech/tablesaw/plotly/components/change/Decreasing.java
+++ b/quicksaw-charts/src/main/java/tech/tablesaw/plotly/components/change/Decreasing.java
@@ -1,5 +1,7 @@
 package tech.tablesaw.plotly.components.change;
 
+import tech.tablesaw.plotly.components.Line;
+
 public class Decreasing extends Change {
 
   private Decreasing(DecreasingBuilder builder) {
@@ -15,6 +17,12 @@ public class Decreasing extends Change {
     @Override
     public DecreasingBuilder fillColor(String color) {
       this.fillColor = color;
+      return this;
+    }
+
+    @Override
+    public DecreasingBuilder line(Line line) {
+      this.line = line;
       return this;
     }
 

--- a/quicksaw-charts/src/main/java/tech/tablesaw/plotly/components/change/Increasing.java
+++ b/quicksaw-charts/src/main/java/tech/tablesaw/plotly/components/change/Increasing.java
@@ -1,5 +1,7 @@
 package tech.tablesaw.plotly.components.change;
 
+import tech.tablesaw.plotly.components.Line;
+
 public class Increasing extends Change {
 
   private Increasing(IncreasingBuilder builder) {
@@ -15,6 +17,12 @@ public class Increasing extends Change {
     @Override
     public Increasing.IncreasingBuilder fillColor(String color) {
       this.fillColor = color;
+      return this;
+    }
+
+    @Override
+    public Increasing.IncreasingBuilder line(Line line) {
+      this.line = line;
       return this;
     }
 

--- a/quicksaw-charts/src/main/resources/change_template.html
+++ b/quicksaw-charts/src/main/resources/change_template.html
@@ -5,4 +5,7 @@
 {% if fillColor is not null %}
     fillcolor: '{{fillColor}}',
 {% endif %}
+{% if line is not null %}
+    line: {{line | raw}},
+{% endif %}
 }

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/plots/PlotlyCandlestickPlot.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/plots/PlotlyCandlestickPlot.java
@@ -2,6 +2,9 @@ package tech.tablesaw.charts.impl.plotly.plots;
 
 import tech.tablesaw.charts.ChartBuilder;
 import tech.tablesaw.plotly.components.Figure;
+import tech.tablesaw.plotly.components.Line;
+import tech.tablesaw.plotly.components.change.Decreasing;
+import tech.tablesaw.plotly.components.change.Increasing;
 import tech.tablesaw.plotly.traces.ScatterTrace;
 import tech.tablesaw.plotly.traces.Trace;
 
@@ -17,10 +20,9 @@ public class PlotlyCandlestickPlot extends PlotlyAbstractPlot {
 
         // TODO : columnForLabels -
         // TODO : columnForDetails -
-        // TODO : columnForColor -
         // TODO : columnForSize -
 
-        ScatterTrace trace =
+        ScatterTrace.ScatterBuilder builder =
                 ScatterTrace.builder(
                         table.dateColumn(xCol),
                         table.numberColumn(openCol),
@@ -28,6 +30,21 @@ public class PlotlyCandlestickPlot extends PlotlyAbstractPlot {
                         table.numberColumn(lowCol),
                         table.numberColumn(closeCol))
                         .type("candlestick")
+                        ;
+        if (traceColors != null && traceColors.length > 1) {
+            builder.decreasing(Decreasing.builder()
+                    .line(Line.builder()
+                            .color(traceColors[0])
+                            .build())
+                    .build());
+            builder.increasing(Increasing.builder()
+                    .line(Line.builder()
+                            .color(traceColors[1])
+                            .build())
+                    .build());
+        }
+
+        ScatterTrace trace = builder
                         .build();
 
         setFigure( new Figure(layout, config, new Trace[]{trace}) );

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/plots/PlotlyOHLCPlot.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/plots/PlotlyOHLCPlot.java
@@ -2,6 +2,9 @@ package tech.tablesaw.charts.impl.plotly.plots;
 
 import tech.tablesaw.charts.ChartBuilder;
 import tech.tablesaw.plotly.components.Figure;
+import tech.tablesaw.plotly.components.Line;
+import tech.tablesaw.plotly.components.change.Decreasing;
+import tech.tablesaw.plotly.components.change.Increasing;
 import tech.tablesaw.plotly.traces.ScatterTrace;
 import tech.tablesaw.plotly.traces.Trace;
 
@@ -17,10 +20,9 @@ public class PlotlyOHLCPlot extends PlotlyAbstractPlot {
 
         // TODO : columnForLabels -
         // TODO : columnForDetails -
-        // TODO : columnForColor -
         // TODO : columnForSize -
 
-        ScatterTrace trace =
+        ScatterTrace.ScatterBuilder builder =
                 ScatterTrace.builder(
                         table.dateColumn(xCol),
                         table.numberColumn(openCol),
@@ -28,6 +30,21 @@ public class PlotlyOHLCPlot extends PlotlyAbstractPlot {
                         table.numberColumn(lowCol),
                         table.numberColumn(closeCol))
                         .type("ohlc")
+                        ;
+        if (traceColors != null && traceColors.length > 1) {
+            builder.decreasing(Decreasing.builder()
+                    .line(Line.builder()
+                            .color(traceColors[0])
+                            .build())
+                    .build());
+            builder.increasing(Increasing.builder()
+                    .line(Line.builder()
+                            .color(traceColors[1])
+                            .build())
+                    .build());
+        }
+
+        ScatterTrace trace = builder
                         .build();
 
         setFigure( new Figure(layout, config, new Trace[]{trace}) );

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/plots/PlotlyTimeSeriesPlot.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/plots/PlotlyTimeSeriesPlot.java
@@ -8,17 +8,29 @@ import tech.tablesaw.table.TableSliceGroup;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.tablesaw.plotly.components.Line;
 
 public class PlotlyTimeSeriesPlot extends PlotlyAbstractPlot {
+
+    private final static Logger LOG = LogManager.getLogger();
 
     public PlotlyTimeSeriesPlot(ChartBuilder chartBuilder, String groupCol) {
         setChartBuilder(chartBuilder);
         String dateColX = columnsForViewColumns[0];
+        if (columnsForViewColumns.length > 1) {
+            LOG.warn("Only one view column is supported but {} received", columnsForViewColumns.length);
+        }
+
         String yCol = columnsForViewRows[0];
+        if (columnsForViewRows.length > 1) {
+            //TODO: Support more columns in columnsForViewRows by creating more figures?
+            LOG.warn("Only one view row is supported but {} received", columnsForViewRows.length);
+        }
 
         // TODO : columnForLabels -
         // TODO : columnForDetails -
-        // TODO : columnForColor -
         // TODO : columnForSize -
 
         List<Table> tableList;
@@ -26,19 +38,40 @@ public class PlotlyTimeSeriesPlot extends PlotlyAbstractPlot {
         if ( groupCol != null ) {
             TableSliceGroup tables = table.splitOn(table.categoricalColumn(groupCol));
             tableList = tables.asTableList();
+
+            if (columnForColor != null) {
+                if (!columnForColor.equals(groupCol)) {
+                    LOG.warn("Cannot use a different color column when a group column is also present for time series plot: color column ignored.");
+                }
+            }
         } else {
-            tableList = new ArrayList<Table>();
-            tableList.add(table);
+            if (columnForColor == null) {
+                tableList = new ArrayList<Table>();
+                tableList.add(table);
+            } else {
+                TableSliceGroup colorTables = table.splitOn(table.categoricalColumn(columnForColor));
+                tableList = colorTables.asTableList();
+            }
         }
 
         ScatterTrace[] traces = new ScatterTrace[tableList.size()];
         for (int i = 0; i < tableList.size(); i++) {
             Table t = tableList.get(i).sortOn(dateColX);
-            traces[i] =
+            ScatterTrace.ScatterBuilder builder =
                     ScatterTrace.builder(t.dateColumn(dateColX), t.numberColumn(yCol))
                             .showLegend(true)
                             .name(tableList.get(i).name())
                             .mode(ScatterTrace.Mode.LINE)
+                            ;
+
+            if (columnForColor == null) {
+                if (traceColors != null && traceColors.length > i) {
+                    builder.line(Line.builder()
+                            .color(traceColors[i])
+                            .build());
+                }
+            }
+            traces[i] = builder
                             .build();
         }
 


### PR DESCRIPTION
This just adds different traces per color column which means Plotly will assign them different colors.

Also column color and trace colors for time series which is basically another kind of line plot.

Also trace colors to OHLC and Candlestick.

What I'm most curious here is how a `group column` interacts with having a `color column`. Should it create more figures when both are set?