### PR TITLE
Adds columnForLabels to heat map plot; removes the TODO for the unsupported columnForSize

### DIFF
--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/plots/PlotlyHeatMapPlot.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/plots/PlotlyHeatMapPlot.java
@@ -9,18 +9,29 @@ import tech.tablesaw.plotly.traces.Trace;
 import tech.tablesaw.util.DoubleArrays;
 
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.tablesaw.plotly.api.TableExtract;
 
 public class PlotlyHeatMapPlot extends PlotlyAbstractPlot {
 
+    private final static Logger LOG = LogManager.getLogger();
+
     public PlotlyHeatMapPlot(ChartBuilder chartBuilder) {
         setChartBuilder(chartBuilder);
+
+        if (columnsForViewRows != null && columnsForViewRows.length > 0) {
+            LOG.warn("No view row supported but {} received", columnsForViewRows.length);
+        }
+
         String categoryCol1 = columnsForViewColumns[0];
         String categoryCol2 = columnsForViewColumns[1];
+        if (columnsForViewColumns.length > 2) {
+            LOG.warn("Only 2 view columns supported but {} received", columnsForViewColumns.length);
+        }
 
-        // TODO : columnForLabels -
         // TODO : columnForDetails -
         // TODO : columnForColor -
-        // TODO : columnForSize -
 
         Table counts = table.xTabCounts(categoryCol1, categoryCol2);
         counts = counts.dropRows(counts.rowCount() - 1);
@@ -33,7 +44,66 @@ public class PlotlyHeatMapPlot extends PlotlyAbstractPlot {
         Object[] y = yColumn.asObjectArray();
         HeatmapTrace trace = HeatmapTrace.builder(x, y, z).build();
 
-        setFigure( new Figure(layout, config, new Trace[]{trace}) );
+        //Semi-related note: if the `y` text is too wide manually changing layout.margin.l
+        // aka .margin(Margin.builder().left(200).build()) will do the trick.
+        Figure.FigureBuilder builder = Figure.builder()
+                .layout(layout)
+                .config(config)
+                .addTraces(new Trace[]{trace});
+
+        if (columnsForLabels != null && columnsForLabels.length > 0) {
+            if (columnsForLabels.length > 1) {
+                LOG.warn("Plot will only take into account the 1st label column ({} received)", columnsForLabels.length);
+            }
+
+            //we find a first labels value for the given categoryCol1.
+            Table summ = table.select(categoryCol1, columnsForLabels[0])
+                    .splitOn(categoryCol1)
+                    .aggregate(columnsForLabels[0], TableExtract.firstString)
+                    //sorting them so they are the same order as as `y`
+                    .sortAscendingOn(categoryCol1);
+            String[] labels = summ
+                    .stringColumn(1)
+                    .asObjectArray();
+
+            //we display that value for non-zero
+            builder.addEventHandlers((String targetName, String divName) -> {
+                return "var textValues = " + tech.tablesaw.plotly.Utils.dataAsString(labels) + ";\n"
+                        //+ targetName + ".layout.annotations = [];\n"
+                        + "var annotations2 = [];\n"
+                        + "for ( var i = 0; i < data[0].y.length; i++ ) {\n"
+                        + "  for ( var j = 0; j < data[0].x.length; j++ ) {\n"
+                        + "    var currentValue = data[0].z[i][j];\n"
+                        + "    if (currentValue != 0.0) {\n"
+                        + "      var textColor = 'white';\n"
+                        //                        + "    }else{\n"
+                        //                        + "      var textColor = 'black';\n"
+                        //                        + "    }\n"
+                        + "      var result = {\n"
+                        + "        xref: 'x1',\n"
+                        + "        yref: 'y1',\n"
+                        + "        x: data[0].x[j],\n"
+                        + "        y: data[0].y[i],\n"
+                        + "        text: textValues[i],\n"
+                        + "        font: {\n"
+                        + "          family: 'Arial',\n"
+                        + "          size: 12,\n"
+                        + "          color: textColor\n"
+                        + "        },\n"
+                        + "        showarrow: false,\n"
+                        + "      };\n"
+                        //                        + "    "+targetName+".layout.annotations.push(result);\n"
+                        + "      annotations2.push(result);\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}\n"
+                        + "layout.annotations = annotations2; //this is part 1 of the refresh trick\n"
+                        + "Plotly.relayout(" + targetName + ", {'layout.annotations': annotations2}); //part 2 of refreshing";
+
+            });
+        }
+
+        setFigure(builder.build());
     }
 
 }

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/TableExtract.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/plotly/api/TableExtract.java
@@ -203,7 +203,7 @@ public class TableExtract {
         }
     };
 
-    static AggregateFunction<StringColumn, String> firstString = new AggregateFunction<StringColumn, String>("First") {
+    public static AggregateFunction<StringColumn, String> firstString = new AggregateFunction<StringColumn, String>("First") {
         @Override
         public String summarize(StringColumn v) {
             return v.isEmpty() ? StringColumnType.missingValueIndicator() : v.get(0);


### PR DESCRIPTION
By default looks something like this:

<img width="1079" alt="Screenshot 2020-04-10 at 19 31 57" src="https://user-images.githubusercontent.com/991554/79007154-45b9ba80-7b63-11ea-8108-2c7fd8d8a600.png">

ie. I'm showing the label only for the non-zero values.

The left size axis is too small for the text (and plotly does not autoresize for some reason).

If something like
```
       chartBuilder.chartType(chartType, chartTypeOptions.toArray())
                .getLayoutBuilder().autosize(true)
                .margin(Margin.builder().left(200).build());
```
is done the chart looks neater:

<img width="1079" alt="Screenshot 2020-04-10 at 19 32 21" src="https://user-images.githubusercontent.com/991554/79007229-68e46a00-7b63-11ea-80e9-71e4d7d54a0e.png">
