### PR TITLE
Display labels for pie plot if the labels colum is set to be the same as the view column

### DIFF
--- a/quicksaw-charts/src/main/java/tech/tablesaw/plotly/traces/PieTrace.java
+++ b/quicksaw-charts/src/main/java/tech/tablesaw/plotly/traces/PieTrace.java
@@ -19,6 +19,26 @@ public class PieTrace extends AbstractTrace {
   private final Object[] labels;
   private final Marker marker;
   private final Domain domain;
+  private final String textinfo;
+
+  public enum TextInfo {
+    NONE("none"),
+    LABEL("label"),
+    TEXT("text"),
+    VALUE("value"),
+    PERCENT("percent");
+
+    private final String value;
+
+    TextInfo(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+  }
 
   private PieTrace(PieBuilder builder) {
     super(builder);
@@ -26,6 +46,7 @@ public class PieTrace extends AbstractTrace {
     this.labels = builder.labels;
     this.marker = builder.marker;
     this.domain = builder.domain;
+    this.textinfo = builder.textinfo;
   }
 
   @Override
@@ -58,6 +79,9 @@ public class PieTrace extends AbstractTrace {
     if (domain != null) {
       context.put("domain", domain.asJavascript());
     }
+    if (textinfo != null) {
+      context.put("textinfo", textinfo);
+    }
     return context;
   }
 
@@ -76,10 +100,22 @@ public class PieTrace extends AbstractTrace {
     private final Object[] labels;
     private Marker marker;
     private Domain domain;
+    private String textinfo;
 
     private PieBuilder(Object[] labels, double[] values) {
       this.labels = labels;
       this.values = values;
+    }
+
+    public PieBuilder addTextInfo(TextInfo info) {
+      if(info == TextInfo.NONE) {
+        this.textinfo = info.toString();
+      } else if(this.textinfo == null) {
+        this.textinfo = info.toString();
+      } else {
+        this.textinfo = this.textinfo + "+" + info.toString();
+      }
+      return this;
     }
 
     public PieBuilder domain(Domain domain) {

--- a/quicksaw-charts/src/main/resources/pie_trace_template.html
+++ b/quicksaw-charts/src/main/resources/pie_trace_template.html
@@ -12,6 +12,9 @@ var {{variableName}} =
 {% if domain is not null %}
         domain: {{domain | raw}},
 {% endif %}
+{% if textinfo is not null %}
+        textinfo: '{{textinfo | raw}}',
+{% endif %}
         type: '{{type}}',
         name: '{{name}}',
  }

--- a/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/plots/PlotlyPiePlot.java
+++ b/simple-web-ui-toolkit/src/main/java/tech/tablesaw/charts/impl/plotly/plots/PlotlyPiePlot.java
@@ -22,10 +22,8 @@ public class PlotlyPiePlot extends PlotlyAbstractPlot {
             LOG.warn("Pie plot will only take into account the 1st view colum ({} received)", columnsForViewColumns.length);
         }
 
-        // TODO : columnForLabels -
         // TODO : columnForDetails -
         // TODO : columnForColor -
-        // TODO : columnForSize -
         if (individualAxes) {
             setFigures(Stream.of(columnsForViewRows)
                     .map(numberColName -> simpleFigure(table, groupColName, numberColName))
@@ -63,6 +61,17 @@ public class PlotlyPiePlot extends PlotlyAbstractPlot {
                 builder.marker(Marker.builder()
                         .colors(traceColors)
                         .build());
+            }
+        }
+        if (columnsForLabels != null && columnsForLabels.length > 0) {
+            if (columnsForLabels.length > 1) {
+                LOG.warn("Plot will only take into account the 1st label colum ({} received)", columnsForLabels.length);
+            }
+            if (groupColName.equals(columnsForLabels[0])) {
+                //makes no sense to have another label column... but when it is set, show the label
+                builder.addTextInfo(PieTrace.TextInfo.LABEL);
+            } else {
+                LOG.warn("Plot will only ignore label colum unless it's the same as a view column");
             }
         }
 


### PR DESCRIPTION
For a pie plot the view column *is* what will be shown as a label. So... in a way it made no sense to support a label column.

But, I figured that this could still be supported somehow:

* by default the chart seems to display the percentage%
* if a label column is set, and if it is set to be the same as the view column, then the chart will show the label instead of the percentage.
<img width="485" alt="Screenshot 2020-04-24 at 20 18 31" src="https://user-images.githubusercontent.com/991554/80239393-d2d33800-8668-11ea-8f22-171a96821e4b.png">
<img width="485" alt="Screenshot 2020-04-24 at 20 18 08" src="https://user-images.githubusercontent.com/991554/80239396-d5359200-8668-11ea-8be6-9c8d40a6b2f5.png">

Let me know if it makes sense.

